### PR TITLE
:bug: Fixed an error when deleting a file if file output to the file system is disabled and the user does not have write permission to the file system.

### DIFF
--- a/binary_database_files/storage.py
+++ b/binary_database_files/storage.py
@@ -142,9 +142,10 @@ class DatabaseStorage(FileSystemStorage):
         name = self.get_instance_name(name)
         try:
             models.File.objects.get_from_name(name).delete()
-            hash_fn = utils.get_hash_fn(name)
-            if os.path.isfile(hash_fn):
-                os.remove(hash_fn)
+            if _settings.DB_FILES_AUTO_EXPORT_DB_TO_FS:
+                hash_fn = utils.get_hash_fn(name)
+                if os.path.isfile(hash_fn):
+                    os.remove(hash_fn)
         except models.File.DoesNotExist:
             pass
         localpath = self._path(name)


### PR DESCRIPTION
`DatabaseStorage.delete`の呼び出し時に、ファイルシステム上にキャッシュがある場合に削除を行う処理があり、その処理で呼び出される`get_hash_fn`関数内で、ファイルシステム上にキャッシュファイルの保存先ディレクトリが存在しなければ作成するという処理があり、その部分でread-onlyであったり書き込み権限がない場合にエラーとなっていた。

https://github.com/CreditEngine/django-binary-database-files/blob/96a7457bb8678c66758afa05c61b1f178cba0399/binary_database_files/utils.py#L36C5-L48

該当関数でディレクトリを作成しないようにする対応方法もあったが、そもそもファイルシステム上にキャッシュを行う設定がoffの場合には、そのキャッシュの削除処理を行わないようにすることで対処。

https://creditengine.slack.com/archives/C0127M395NV/p1691633013314179